### PR TITLE
Firefox support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,4 +1,9 @@
 {
+  "applications": {
+    "gecko": {
+      "id": "andrewallanwallace@gmail.com"
+    }
+  },
   "name": "Gmail Filter Helper",
   "description": "This is a extension that help you create Gmail spam filter more easily and quickly by one click",
   "version": "1.0",

--- a/popup.html
+++ b/popup.html
@@ -2,11 +2,8 @@
 <html>
   <head>
     <title>Set Page Color Popup</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
     <style>
-    
-
-    
-
     div {
       text-align: center;
       vertical-align: middle;
@@ -15,10 +12,7 @@
       font-size: 12pt;
       width: 150px;
       height: 20px;
-      
     }
-    
-    
     </style>
     <script src="popup.js"></script>
   </head>

--- a/popup.js
+++ b/popup.js
@@ -1,15 +1,15 @@
 
 function click(e) {
-	var element = e.srcElement;
+	var element = e.target;
 	var spamScript ;
 	if (element.id == 'create_filter_by_email') {
 		spamScript = 'startWithEmail()';
 	} else if (element.id == 'create_filter_by_domain') {
 		spamScript = 'startWithDomain()';
 	}
-  	chrome.tabs.executeScript(null,
+	chrome.tabs.executeScript(null,
       	{code:spamScript});
-  	window.close();
+	window.close();
 }
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/utils.js
+++ b/utils.js
@@ -81,7 +81,8 @@ function findElementByClassName(element, className) {
 		logMessage("get elements by className " + className)
 		if (elements && !isDataSourceEmpty(elements)) {
 			logMessage("use element className=" + className);
-			if (elements[0].innerText.match("@")) {
+			var text = elements[0].innerText || elements[0].textContent;
+			if (text.match("@")) {
 				element = elements[0];
 			}
 		}
@@ -93,7 +94,7 @@ function findEmailText() {
 	var emailTextView = undefined;
 	emailTextView = findElementByClassName(emailTextView, "gD");	
 	emailTextView = findElementByClassName(emailTextView, 'go');
-	return emailTextView.innerText;
+	return emailTextView.innerText || emailTextView.textContent;
 }
 
 


### PR DESCRIPTION
1. Make the extension support Firefox
   a. Add applications info in manifest;
   b. Change e.srcElement to e.target in popup.js
   c. Change .innerText to .innerText || .textContent
2. Add Content-Type in popup.html.

Note: With the changes Chrome shows warning that it does not recognize manifest key 'applications', but the extension still works OK.
